### PR TITLE
[ENH] Add function to remove leading zeros from run names

### DIFF
--- a/bidsutils/dataset.py
+++ b/bidsutils/dataset.py
@@ -1,4 +1,5 @@
 import re
+import os
 import os.path as op
 import shutil
 
@@ -31,7 +32,7 @@ def fix_runs(layout):
     files = layout.get()
     for f in files:
         out_fname = re.sub(RUN_REGEX, RUN_OUT_REGEX, f.path)
-        rename(f.path, out_fname)
+        os.rename(f.path, out_fname)
 
 
 def merge_datasets(source_dset, target_dset, project_name, sub, ses=None):

--- a/bidsutils/dataset.py
+++ b/bidsutils/dataset.py
@@ -17,7 +17,8 @@ def fix_runs(layout):
     """
     RUN_REGEX = r'(_run-)[0]+(\d+_)'
     RUN_OUT_REGEX = r'\1\2'
-    # Rename files in field-map jsons
+
+    # Rename contents of text files
     text_files = layout.get(extension=['json', 'tsv'])
     for f in text_files:
         with open(f, 'r') as fo:

--- a/bidsutils/dataset.py
+++ b/bidsutils/dataset.py
@@ -1,7 +1,36 @@
+import re
 import os.path as op
 import shutil
 
 import pandas as pd
+
+
+def fix_runs(layout):
+    """Remove zero-padding from run numbers in a dataset.
+
+    A common mistake in dataset preparation is to include leading zeros in run
+    numbers (e.g., *_run-01_* instead of _run-1_*).
+
+    Parameters
+    ----------
+    layout : bids.BIDSLayout
+    """
+    RUN_REGEX = r'(_run-)[0]+(\d+_)'
+    RUN_OUT_REGEX = r'\1\2'
+    # Rename files in field-map jsons
+    text_files = layout.get(extension=['json', 'tsv'])
+    for f in text_files:
+        with open(f, 'r') as fo:
+            d = fo.read()
+        d = re.sub(RUN_REGEX, RUN_OUT_REGEX, d)
+        with open(f, 'w') as fo:
+            fo.write(d)
+
+    # Rename files
+    files = layout.get()
+    for f in files:
+        out_fname = re.sub(RUN_REGEX, RUN_OUT_REGEX, f.path)
+        rename(f.path, out_fname)
 
 
 def merge_datasets(source_dset, target_dset, project_name, sub, ses=None):


### PR DESCRIPTION
Adds `bidsutils.dataset.fix_runs()`, which takes in a BIDSLayout and removes all leading zeros from run names throughout the dataset, both in filenames and in the contents of text-based files.